### PR TITLE
Do not log the authorization token

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -177,6 +177,15 @@ abstract class Request {
 		$decoded_body         = json_decode( $request_body );
 		$request_args['body'] = $decoded_body ?? $request_args['body'] ?? null;
 
+		// Do not log the authorization token.
+		foreach ( $request_args['headers'] as $header => $value ) {
+			if ( 'authorization' === strtolower( $header ) ) {
+				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
+				break;
+			}
+		}
+
 		// Log the response.
 		Logger::log(
 			$this->config['slug'],

--- a/src/Request.php
+++ b/src/Request.php
@@ -177,14 +177,7 @@ abstract class Request {
 		$decoded_body         = json_decode( $request_body );
 		$request_args['body'] = $decoded_body ?? $request_args['body'] ?? null;
 
-		// Do not log the authorization token.
-		foreach ( $request_args['headers'] as $header => $value ) {
-			if ( 'authorization' === strtolower( $header ) ) {
-				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
-				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
-				break;
-			}
-		}
+		$request_args = $this->sanitize_request_args( $request_args );
 
 		// Log the response.
 		Logger::log(
@@ -204,6 +197,25 @@ abstract class Request {
 				'plugin_version' => $this->config['plugin_version'],
 			)
 		);
+	}
+
+	/**
+	 * Remove sensitive data from the log.
+	 *
+	 * @param array $request_args The request data to sanitize.
+	 * @return array The request data sanitized.
+	 */
+	protected function sanitize_request_args( $request_args ) {
+		// Do not log the authorization token.
+		foreach ( $request_args['headers'] as $header => $value ) {
+			if ( 'authorization' === strtolower( $header ) ) {
+				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
+				break;
+			}
+		}
+
+		return $request_args;
 	}
 
 	/**


### PR DESCRIPTION
This has been tested, and verified to work as expected with Klarna Payments.

Assumptions:

- if it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
- you have at most one authorization header (hence the `break`).