### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+------------------
+## [1.1.0] - 2023-12-04
+### Fixed
+* Fixed an issue that would cause a error notice when there was no body set. For example with GET requests.
+
+### Added
+* Added sanitation of the auth headers for the requests. This will prevent the auth headers from being logged if its above a certain length. This is to prevent the auth headers from being logged in the logs if they are correct, but still leave information in the logs if they are incorrect.
+
 ## [1.0.1] - 2023-02-27
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "krokedil/wp-api",
     "description": "A composer library for Krokedil WordPress plugins that contains classes for working with wp_remote_request to setup request classes. Also uses the WooCommerce logger to log request reponses.",
     "type": "library",
+    "version": "1.1.0",
     "require-dev": {
         "php": "~7.1 || ~8.0",
         "php-stubs/wordpress-stubs": "^6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8209666a206c67addb82877fb234750b",
+    "content-hash": "5bcd49ae56f040ea5b432f98dd63b11f",
     "packages": [],
     "packages-dev": [
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v7.3.0",
+            "version": "v7.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "446c335118632e00854b9ada74319b200e5c78a2"
+                "reference": "3a2f522e29451490c357af550227795d2b0fc55a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/446c335118632e00854b9ada74319b200e5c78a2",
-                "reference": "446c335118632e00854b9ada74319b200e5c78a2",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/3a2f522e29451490c357af550227795d2b0fc55a",
+                "reference": "3a2f522e29451490c357af550227795d2b0fc55a",
                 "shasum": ""
             },
             "require": {
@@ -47,37 +47,37 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.3.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v7.9.0"
             },
-            "time": "2023-01-13T00:24:42+00:00"
+            "time": "2023-07-17T22:41:38+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.1.0",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "19e7966c8e70a99a4824b3e5d1526680a151f13b"
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/19e7966c8e70a99a4824b3e5d1526680a151f13b",
-                "reference": "19e7966c8e70a99a4824b3e5d1526680a151f13b",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6d6063cf9464a306ca2a0529705d41312b08500b",
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b",
                 "shasum": ""
             },
-            "replace": {
-                "giacocorsiglia/wordpress-stubs": "*"
-            },
             "require-dev": {
-                "nikic/php-parser": "< 4.12.0",
-                "php": "~7.3 || ~8.0",
-                "php-stubs/generator": "^0.8.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
+                "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.2"
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.8"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
             "type": "library",
@@ -94,9 +94,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.1.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.1"
             },
-            "time": "2022-11-09T05:33:25+00:00"
+            "time": "2023-11-10T00:33:47+00:00"
         }
     ],
     "aliases": [],
@@ -108,5 +108,5 @@
     "platform-dev": {
         "php": "~7.1 || ~8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -177,6 +177,15 @@ abstract class Request {
 		$decoded_body         = json_decode( $request_body );
 		$request_args['body'] = $decoded_body ?? $request_args['body'] ?? null;
 
+		// Do not log the authorization token.
+		foreach ( $request_args['headers'] as $header => $value ) {
+			if ( 'authorization' === strtolower( $header ) ) {
+				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
+				break;
+			}
+		}
+
 		// Log the response.
 		Logger::log(
 			$this->config['slug'],

--- a/src/Request.php
+++ b/src/Request.php
@@ -170,12 +170,12 @@ abstract class Request {
 
 		// Get the response body if its not a WP_Error.
 		$response_body = ! is_wp_error( $response ) ? json_decode( wp_remote_retrieve_body( $response ), true ) : array();
-		$code = wp_remote_retrieve_response_code( $response );
+		$code          = wp_remote_retrieve_response_code( $response );
 
 		// Parse the Request body into an array if its json format.
-		$request_body  = $request_args['body'];
-		$decoded_body  = json_decode( $request_body );
-		$request_args['body'] = $decoded_body ?? $request_args['body'];
+		$request_body         = $request_args['body'] ?? '';
+		$decoded_body         = json_decode( $request_body );
+		$request_args['body'] = $decoded_body ?? $request_args['body'] ?? null;
 
 		// Log the response.
 		Logger::log(

--- a/src/Request.php
+++ b/src/Request.php
@@ -177,14 +177,7 @@ abstract class Request {
 		$decoded_body         = json_decode( $request_body );
 		$request_args['body'] = $decoded_body ?? $request_args['body'] ?? null;
 
-		// Do not log the authorization token.
-		foreach ( $request_args['headers'] as $header => $value ) {
-			if ( 'authorization' === strtolower( $header ) ) {
-				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
-				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
-				break;
-			}
-		}
+		$request_args = $this->sanitize_request_args( $request_args );
 
 		// Log the response.
 		Logger::log(
@@ -204,6 +197,25 @@ abstract class Request {
 				'plugin_version' => $this->config['plugin_version'],
 			)
 		);
+	}
+
+	/**
+	 * Remove sensitive data from the log.
+	 *
+	 * @param array $request_args The request data to sanitize.
+	 * @return array The request data sanitized.
+	 */
+	protected function sanitize_request_args( $request_args ) {
+		// Do not log the authorization token.
+		foreach ( $request_args['headers'] as $header => $value ) {
+			if ( 'authorization' === strtolower( $header ) ) {
+				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[redacted]' : '[missing]';
+				break;
+			}
+		}
+
+		return $request_args;
 	}
 
 	/**


### PR DESCRIPTION
### Fixed
* Fixed an issue that would cause a error notice when there was no body set. For example with GET requests.

### Added
* Added sanitation of the auth headers for the requests. This will prevent the auth headers from being logged if its above a certain length. This is to prevent the auth headers from being logged in the logs if they are correct, but still leave information in the logs if they are incorrect.