### PR TITLE
Tweak timestamp to be compliant with WP

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -200,7 +200,7 @@ abstract class Request {
 					'body' => $response_body,
 					'code' => $code,
 				),
-				'timestamp'      => date( 'Y-m-d H:i:s' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
+				'timestamp'      => current_time( 'mysql' ),
 				'stack'          => Logger::get_stack( $this->config['extended_debugging'] ),
 				'plugin_version' => $this->config['plugin_version'],
 			)


### PR DESCRIPTION
An attempt to better adhere to WordPress standard, by following the Woo Quality Insights reported errors/warnings.

Many of these might be unnecessary or plain wrong; let me know what you think should be kept (if anything).

**Not thoroughly tested**; I will make sure to do so for each of these branches if the changes seems reasonable.